### PR TITLE
Cursor.callproc method

### DIFF
--- a/src/cxoCursor.c
+++ b/src/cxoCursor.c
@@ -1327,7 +1327,11 @@ static PyObject *cxoCursor_callProc(cxoCursor *cursor, PyObject *args,
         return NULL;
 
     // create the return value
-    numArgs = PyList_GET_SIZE(cursor->bindVariables);
+    numArgs = 0;
+    if (listOfArguments) {
+        //check already made in cxoCursor_call
+        numArgs = PySequence_Size(listOfArguments);
+    }
     results = PyList_New(numArgs);
     if (!results)
         return NULL;

--- a/test/Cursor.py
+++ b/test/Cursor.py
@@ -86,6 +86,37 @@ class TestCase(TestEnv.BaseTestCase):
         results = self.cursor.callproc("proc_Test", ("hi", 5, var))
         self.assertEqual(results, ["hi", 10, 2.0])
 
+    def testCallProcAllKeywords(self):
+        """test executing a stored procedure with arguments in keywordParameters"""
+        kwargs = dict(
+            a_InValue = "hi",
+            a_InOutValue = self.cursor.var(cx_Oracle.NUMBER),
+            a_OutValue = self.cursor.var(cx_Oracle.NUMBER),
+        )
+        kwargs['a_InOutValue'].setvalue(0, 5)
+        results = self.cursor.callproc("proc_Test", keywordParameters=kwargs)
+        self.assertEqual(results, [])
+        self.assertEqual(kwargs['a_InOutValue'].getvalue(), 10)
+        self.assertEqual(kwargs['a_OutValue'].getvalue(), 2.0)
+
+    def testCallProcOnlyLastKeyword(self):
+        """test executing a stored procedure with last argument in keywordParameters"""
+        kwargs = dict(
+            a_OutValue = self.cursor.var(cx_Oracle.NUMBER),
+        )
+        results = self.cursor.callproc("proc_Test", ("hi",5), kwargs)
+        self.assertEqual(results, ["hi", 10])
+        self.assertEqual(kwargs['a_OutValue'].getvalue(), 2.0)
+
+    def testCallProcRepeatedKeywordParameters(self):
+        """test executing a stored procedure with repeated argument in keywordParameters"""
+        kwargs = dict(
+            a_InValue = "hi",
+            a_OutValue = self.cursor.var(cx_Oracle.NUMBER),
+        )
+        self.assertRaises(cx_Oracle.DatabaseError, self.cursor.callproc,
+                "proc_Test", parameters=("hi",5), keywordParameters=kwargs)
+
     def testCallProcNoArgs(self):
         """test executing a stored procedure without any arguments"""
         results = self.cursor.callproc(u"proc_TestNoArgs")


### PR DESCRIPTION
Hello Anthony!
Problem solved is very small, just clarification of document string Cursor.callproc method that

> Keyword parameters will be included after the positional parameters and are not returned as part of the output sequence.
Thank you for good python interface.

Signed-off-by: Andrey Petukhov <APetukhov@bellintegrator.com>

Thanks for contributing!

Before submitting PRs for cx_Oracle you must have your signed *Oracle
Contributor Agreement* accepted.  See
https://www.oracle.com/technetwork/community/oca-486395.html

If the problem solved is small, you may find it easier to open an Issue
describing the problem and its cause so we can create the fix.

The bottom of your commit message must have the following line using your name
and e-mail address as it appears in the OCA Signatories list.

```
Signed-off-by: Your Name <you@example.org>
```

This can be automatically added to pull requests by committing with:

```
git commit --signoff
````
