### PR TITLE
Remove redundant assignment from cxoCursor_setBindVariables

### DIFF
--- a/src/cxoCursor.c
+++ b/src/cxoCursor.c
@@ -782,7 +782,6 @@ int cxoCursor_setBindVariables(cxoCursor *cursor, PyObject *parameters,
         else cursor->bindVariables = PyDict_New();
         if (!cursor->bindVariables)
             return -1;
-        origNumParams = 0;
     }
 
     // handle positional binds


### PR DESCRIPTION
origNumParams was set to 0 a few lines earlier and cannot be changed in between.