### PR TITLE
Fix memory leak on error path in cxoObjectType_initialize

### DIFF
--- a/src/cxoObjectType.c
+++ b/src/cxoObjectType.c
@@ -146,8 +146,10 @@ static int cxoObjectType_initialize(cxoObjectType *objType,
         }
         PyList_SET_ITEM(objType->attributes, i, (PyObject*) attr);
         if (PyDict_SetItem(objType->attributesByName, attr->name,
-                (PyObject*) attr) < 0)
+                (PyObject*) attr) < 0) {
+            PyMem_Free(attributes);
             return -1;
+        }
     }
     PyMem_Free(attributes);
     return 0;


### PR DESCRIPTION
The `attributes` array is not passed out of this function, so it needs to be released no matter what when the function exits.