### PR TITLE
Create TestLongs and TestLongRaws tables without compression

### DIFF
--- a/test/sql/SetupTestExec.sql
+++ b/test/sql/SetupTestExec.sql
@@ -178,13 +178,13 @@ create table &main_user..TestXML (
 create table &main_user..TestLongs (
     IntCol                              number(9) not null,
     LongCol                             long not null
-)
+) nocompress
 /
 
 create table &main_user..TestLongRaws (
     IntCol                              number(9) not null,
     LongRawCol                          long raw not null
-)
+) nocompress
 /
 
 create table &main_user..TestTempTable (


### PR DESCRIPTION
Without these changes, I get `cx_Oracle.DatabaseError: ORA-64308: hybrid columnar compressed table cannot have column with LONG data type` in TestEnv.py when connecting to an Oracle Cloud database.