### PR TITLE
Make numConnectDataArgs const

### DIFF
--- a/src/cxoModule.c
+++ b/src/cxoModule.c
@@ -179,7 +179,7 @@ static int cxoModule_setException(PyObject *module, PyObject **exception,
 static PyObject* cxoModule_makeDSN(PyObject* self, PyObject* args,
         PyObject* keywordArgs)
 {
-    static unsigned int numConnectDataArgs = 5;
+    static const unsigned int numConnectDataArgs = 5;
     static char *keywordList[] = { "host", "port", "sid", "service_name",
             "region", "sharding_key", "super_sharding_key", NULL };
     PyObject *result, *connectData, *hostObj, *portObj;


### PR DESCRIPTION
It's good practice to mark values like this as `const` as a hint to the compiler to inline them and as a hint to the programmer that the value does not change.