### PR TITLE
docs: fix simple typo, tranform -> transform

### DIFF
--- a/src/cxoVar.c
+++ b/src/cxoVar.c
@@ -501,7 +501,7 @@ static int cxoVar_setSingleValue(cxoVar *var, uint32_t arrayPos,
         value = convertedValue;
     }
 
-    // tranform value from Python to value expected by ODPI-C
+    // transform value from Python to value expected by ODPI-C
     data = &var->data[arrayPos];
     data->isNull = (value == Py_None);
     if (!data->isNull) {


### PR DESCRIPTION
There is a small typo in src/cxoVar.c.

Should read `transform` rather than `tranform`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md