### PR TITLE
 Extra word 'could' in documentation exception_handling.rst #550  -- Fix

### DIFF
--- a/doc/src/user_guide/exception_handling.rst
+++ b/doc/src/user_guide/exception_handling.rst
@@ -11,7 +11,7 @@ defined by cx_Oracle. See the exception handling section in the
 when an exception is raised.
 
 Applications can catch exceptions as needed. For example, when trying to add a
-customer that already exists in the database, the following could could be used
+customer that already exists in the database, the following could be used
 to catch the exception:
 
 .. code-block:: python


### PR DESCRIPTION
Fixed the bug --  Extra word 'could' in documentation exception_handling.rst #550

Signed-off-by: Soumyadip Saha <soumyadip.saha@iiitb.org>
Thanks for contributing!

Before submitting PRs for cx_Oracle you must have your signed *Oracle
Contributor Agreement* accepted.  See
https://www.oracle.com/technetwork/community/oca-486395.html

If the problem solved is small, you may find it easier to open an Issue
describing the problem and its cause so we can create the fix.

The bottom of your commit message must have the following line using your name
and e-mail address as it appears in the OCA Signatories list.

```
Signed-off-by: Your Name <you@example.org>
```

This can be automatically added to pull requests by committing with:

```
git commit --signoff
````
