### PR TITLE
Removed an extra "could" in line no. 14

### DIFF
--- a/doc/src/user_guide/exception_handling.rst
+++ b/doc/src/user_guide/exception_handling.rst
@@ -11,7 +11,7 @@ defined by cx_Oracle. See the exception handling section in the
 when an exception is raised.
 
 Applications can catch exceptions as needed. For example, when trying to add a
-customer that already exists in the database, the following could could be used
+customer that already exists in the database, the following could be used
 to catch the exception:
 
 .. code-block:: python


### PR DESCRIPTION
Extra word 'could' in documentation exception_handling.rst #550 -- Fix #551 --> fix of this bug
Signed-off-by: Soumyadip Saha <soumyadip.saha@iiitb.org>