### PR TITLE
Fix build failure by pinning setuptools <82

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools >= 40.6.0", "wheel"]
+requires = ["setuptools >= 40.6.0, <82", "wheel"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Old requirements files using this still break on Python 3.11 since it asks for setuptools>=40, then it gets setuptools=82.0.0 which [removed pkg_resources](https://setuptools.pypa.io/en/stable/history.html#deprecations-and-removals) completely.

This fix should avoid those issues until cx-oracle can be removed  

```
root@941000aee117:/code/base$ pip install cx-oracle --verbose
Using pip 25.1.1 from /code/venvs/venv/lib/python3.11/site-packages/pip (python 3.11)
Looking in indexes: https://<>/artifactory/api/pypi/virtual-pypi-jammy/simple/
Collecting cx-oracle
  Downloading https://<>/artifactory/api/pypi/virtual-pypi-jammy/cx-Oracle/8.3.0/cx_Oracle-8.3.0.tar.gz (363 kB)
  Running command pip subprocess to install build dependencies
  Using pip 25.1.1 from /code/venvs/venv/lib/python3.11/site-packages/pip (python 3.11)
  Looking in indexes: https://<>/artifactory/api/pypi/virtual-pypi-jammy/simple/
  Collecting setuptools>=40.6.0
    Downloading https://<>/artifactory/api/pypi/virtual-pypi-jammy/setuptools/82.0.0/setuptools-82.0.0-py3-none-any.whl (1.0 MB)
       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.0/1.0 MB 1.2 MB/s eta 0:00:00
  Collecting wheel
    Downloading https://<>/artifactory/api/pypi/virtual-pypi-jammy/wheel/0.45.1/wheel-0.45.1-py3-none-any.whl (72 kB)
  Installing collected packages: wheel, setuptools
    Creating /tmp/pip-build-env-sztpvfuu/overlay/bin
    changing mode of /tmp/pip-build-env-sztpvfuu/overlay/bin/wheel to 755

  Successfully installed setuptools-82.0.0 wheel-0.45.1
  Installing build dependencies ... done
  Running command Getting requirements to build wheel
  Traceback (most recent call last):
    File "/code/venvs/venv/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 389, in <module>
      main()
    File "/code/venvs/venv/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 373, in main
      json_out["return_val"] = hook(**hook_input["kwargs"])
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/code/venvs/venv/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 143, in get_requires_for_build_wheel
      return hook(config_settings)
             ^^^^^^^^^^^^^^^^^^^^^
    File "/tmp/pip-build-env-sztpvfuu/overlay/lib/python3.11/site-packages/setuptools/build_meta.py", line 333, in get_requires_for_build_wheel
      return self._get_build_requires(config_settings, requirements=[])
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/tmp/pip-build-env-sztpvfuu/overlay/lib/python3.11/site-packages/setuptools/build_meta.py", line 301, in _get_build_requires
      self.run_setup()
    File "/tmp/pip-build-env-sztpvfuu/overlay/lib/python3.11/site-packages/setuptools/build_meta.py", line 317, in run_setup
      exec(code, locals())
    File "<string>", line 6, in <module>
  ModuleNotFoundError: No module named 'pkg_resources'
  error: subprocess-exited-with-error
```



Thanks for contributing!

The cx_Oracle driver was renamed to python-oracledb in May 2022.  It has a new
repository at https://github.com/oracle/python-oracledb.

Please submit your contributions to the python-oracledb repository.

No further releases under the cx_Oracle namespace are planned.


